### PR TITLE
chore: bind try to change name signal to returnPressed

### DIFF
--- a/dcc-deepinid-plugin/operation/syncworker.cpp
+++ b/dcc-deepinid-plugin/operation/syncworker.cpp
@@ -604,7 +604,6 @@ void SyncWorker::asyncUnbindAccount(const QString &ubid)
     watcher->setFuture(future);
 }
 
-// NOTE: unexist interface
 void SyncWorker::asyncSetFullname(const QString &fullname)
 {
     QDBusInterface utInterface("com.deepin.sync.Daemon",

--- a/dcc-deepinid-plugin/pages/logininfo.cpp
+++ b/dcc-deepinid-plugin/pages/logininfo.cpp
@@ -214,7 +214,7 @@ void LoginInfoPage::initConnection()
         }
     });
 
-    connect(m_inputLineEdit, &DLineEdit::editingFinished, this, [ = ] {
+    connect(m_inputLineEdit, &DLineEdit::returnPressed, this, [ = ] {
         QString userFullName = m_inputLineEdit->lineEdit()->text();
         onEditingFinished(userFullName);
     });


### PR DESCRIPTION
when it is not focus or press enter, it will all emit editfinished, so just bind it to pressenter

Log: