### PR TITLE
fix: Fix bug when deepin id shows not activated after login

### DIFF
--- a/dcc-deepinid-plugin/operation/syncworker.cpp
+++ b/dcc-deepinid-plugin/operation/syncworker.cpp
@@ -730,7 +730,7 @@ void SyncWorker::getUserDeepinidInfo()
 
 void SyncWorker::getLicenseState()
 {
-    if (DSysInfo::DeepinDesktop == DSysInfo::deepinType()) {
+    if (DSysInfo::uosEditionType() == DSysInfo::UosCommunity) {
         m_model->setActivation(true);
         return;
     }


### PR DESCRIPTION
/etc/deepin-version was deprecated. Move to apis utilizing /etc/os-version instead.

Issue: https://github.com/linuxdeepin/developer-center/issues/9904
Log: Fix bug when deepin id shows not activated after login