### PR TITLE
fix: 修复背景图不等比例缩放和tip样式不对

### DIFF
--- a/dcc-deepinid-plugin/pages/login.cpp
+++ b/dcc-deepinid-plugin/pages/login.cpp
@@ -142,14 +142,22 @@ PicLabel::PicLabel(QWidget *parent): QLabel (parent), m_svgrender(new QSvgRender
 void PicLabel::SetImage(const QString &imgurl)
 {
     m_svgrender->load(imgurl);
+    m_defSize = m_svgrender->defaultSize();
 }
 
 void PicLabel::resizeEvent(QResizeEvent *event)
 {
-    Q_UNUSED(event);
-    QPixmap pixmap(size() * qApp->devicePixelRatio());
+    QSize finalSize = m_defSize;
+    QSize newSize = size();
+    if(m_defSize.width() < newSize.width() ||
+        m_defSize.height() < newSize.height()) {
+        finalSize.scale(newSize, Qt::KeepAspectRatioByExpanding);
+    }
+
+    QPixmap pixmap(finalSize * qApp->devicePixelRatio());
     pixmap.fill(Qt::transparent);
     QPainter painter(&pixmap);
+    m_svgrender->setAspectRatioMode(Qt::IgnoreAspectRatio);
     m_svgrender->render(&painter);
     pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
     setPixmap(pixmap);

--- a/dcc-deepinid-plugin/pages/login.h
+++ b/dcc-deepinid-plugin/pages/login.h
@@ -21,6 +21,7 @@ public:
 protected:
     void resizeEvent(QResizeEvent *event) override;
 private:
+    QSize        m_defSize;
     QSvgRenderer *m_svgrender;
 };
 


### PR DESCRIPTION
修复背景图没有等比例缩放和tip样式不对的问题

Issue: https://github.com/linuxdeepin/developer-center/issues/10308
Log: 修复背景图不等比例缩放和tip样式不对